### PR TITLE
Arreglo de un bug en router

### DIFF
--- a/lib/core/router/app-router.dart
+++ b/lib/core/router/app-router.dart
@@ -10,7 +10,6 @@ import 'package:nutrabit_paciente/presentations/screens/calendar/calendar.dart';
 import 'package:nutrabit_paciente/presentations/screens/calendar/patient_calendarDay.dart';
 import 'package:nutrabit_paciente/presentations/screens/home.dart';
 import 'package:nutrabit_paciente/presentations/screens/homeOffline.dart';
-import 'package:nutrabit_paciente/presentations/screens/interest_list/listaInteres.dart';
 import 'package:nutrabit_paciente/presentations/screens/login.dart';
 import 'package:nutrabit_paciente/presentations/screens/notifications/detalleNotificacion.dart';
 import 'package:nutrabit_paciente/presentations/screens/notifications/notificaciones.dart';
@@ -19,8 +18,6 @@ import 'package:nutrabit_paciente/presentations/screens/password/forgot_password
 import 'package:nutrabit_paciente/presentations/screens/profile/patient_detail.dart';
 import 'package:nutrabit_paciente/presentations/screens/profile/validation_profile/profile_dynamic_screen.dart';
 import 'package:nutrabit_paciente/presentations/screens/profile/validation_profile/select_goal_screen.dart';
-import 'package:nutrabit_paciente/presentations/screens/publicity/detallePublicidad.dart';
-import 'package:nutrabit_paciente/presentations/screens/publicity/publicidades.dart';
 import 'package:nutrabit_paciente/presentations/screens/profile/turnos/turnos.dart';
 import 'package:nutrabit_paciente/presentations/screens/welcome/welcomeCarousel.dart';
 import 'package:nutrabit_paciente/presentations/screens/profile/patient_modifier.dart';
@@ -53,9 +50,7 @@ final routerProvider = Provider<GoRouter>((ref) {
       final seenWelcome = seenWelcomeState;
       final dontShowWelcome = await sharedPreferencesService.getdontShowAgain();
 
-      if (dontShowWelcome == false && seenWelcome == false && isWelcome) {
-        ref.read(welcomeSessionProvider.notifier).state = true;
-      }
+      // Aquí ya no mutas el estado, solo decides rutas
 
       if (!loggedIn && dontShowWelcome == false) {
         if (isWelcome || isAmIPatient || isLogin || isNotPatient) return null;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nutrabit_paciente/core/router/app-router.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:intl/date_symbol_data_local.dart';
 import 'firebase_options.dart';
 
 void main() async {

--- a/lib/presentations/screens/files/download_screen.dart
+++ b/lib/presentations/screens/files/download_screen.dart
@@ -20,10 +20,12 @@ class DownloadScreen extends ConsumerWidget {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
 
-    if (appUser is AsyncError || appUser.value == null) {
-      Future.microtask(
-        () => Navigator.of(context).pushReplacementNamed('/login'),
-      );
+   if (appUser is AsyncError || appUser.value == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) {
+          Navigator.of(context).pushReplacementNamed('/login');
+        }
+      });
       return const SizedBox.shrink();
     }
 
@@ -137,7 +139,6 @@ class FileListTile extends ConsumerWidget {
               );
             },
             icon: const Icon(Icons.picture_as_pdf, size: 20),
-            // label: const Text(''),
             style: ElevatedButton.styleFrom(
               backgroundColor: Colors.grey.shade100,
               foregroundColor: Colors.black,
@@ -168,7 +169,6 @@ class FileListTile extends ConsumerWidget {
                   isDownloaded ? Icons.check_circle : Icons.download,
                   size: 20,
                 ),
-                //label: Text(),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.grey.shade100,
                   foregroundColor: Colors.black,

--- a/lib/presentations/screens/welcome/welcomeCarousel.dart
+++ b/lib/presentations/screens/welcome/welcomeCarousel.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:nutrabit_paciente/presentations/providers/user_provider.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:nutrabit_paciente/presentations/screens/welcome/welcome.dart';
 import 'package:nutrabit_paciente/presentations/screens/welcome/reminder.dart';
@@ -50,6 +51,12 @@ class _WelcomeCarouselState extends ConsumerState<WelcomeCarousel> {
   @override
   void initState() {
     super.initState();
+
+    // ✅ Cambiar el estado welcomeSessionProvider al entrar a /welcome
+    Future.microtask(() {
+      ref.read(welcomeSessionProvider.notifier).state = true;
+    });
+
     _startAutoScroll();
 
     _controller.addListener(() {


### PR DESCRIPTION
      if (dontShowWelcome == false && seenWelcome == false && isWelcome) {
        ref.read(welcomeSessionProvider.notifier).state = true;
      }
Exception has occurred.
_AssertionError ('package:riverpod/src/framework/element.dart': Failed assertion: line 675 pos 7: '!_didChangeDependency': Cannot use ref functions after the dependency of a provider changed but before the provider rebuilt)
Solucionado, movi la actualizacion del welcome provider a la pantalla welcome en lugar de que estuviera en el router, los demas cambios son eliminacion de imports que sobraban y una cosita en download_screen